### PR TITLE
feat: pigeons service install works on Fedora CoreOS

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -51,6 +51,7 @@ pub fn resolve_binary_path() -> anyhow::Result<PathBuf> {
             "/opt/",
             "/usr/local/sbin",
             "/usr/sbin",
+            "/var/usrlocal/bin/",
         ];
 
         let path_str = resolved

--- a/src/service.rs
+++ b/src/service.rs
@@ -51,7 +51,7 @@ pub fn resolve_binary_path() -> anyhow::Result<PathBuf> {
             "/opt/",
             "/usr/local/sbin",
             "/usr/sbin",
-            "/var/usrlocal/bin/",
+            "/var/usrlocal/bin/", // `/usr/local/bin` is a symlink to this in immutable Fedora distros.
         ];
 
         let path_str = resolved


### PR DESCRIPTION
This change resolves https://github.com/n0-computer/pigeons/issues/17