### PR TITLE
feat: ask about anonymous telemetry on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,43 @@ The tunnel is also usable as a library. Add it with `cargo add iroh-pigeons`;
 the API is documented on [docs.rs][Rust Docs]. Note that the crate is published
 as `iroh-pigeons` while the CLI it installs is called `pigeons`.
 
+## Telemetry
+
+The first time you run a setup command (`roost`, `fly`, `add`, or `service
+install`) in a terminal, pigeons asks once whether it may send anonymous
+metrics to help us develop [iroh]. Both answers are recorded in the config file
+that `pigeons paths` prints, so the question is asked once:
+
+```toml
+telemetry_enabled = true
+```
+
+Change that key whenever you like, or delete the file to be asked again.
+Nothing is sent unless it is `true`.
+
+What gets sent are iroh endpoint counters, sampled once a minute and pushed to
+[iroh-services]: relay usage, hole-punching success, bytes moved. No hostnames,
+usernames, SSH traffic, or anything about the machines you connect to. The
+report travels over an iroh connection, so the sending endpoint ID is visible
+to the collector.
+
+The setting has two layers. Your own config wins, and any key it leaves unset
+falls back to a machine-wide config at `/etc/pigeons/config.toml`, or
+`C:\ProgramData\pigeons\config.toml` on Windows. Both paths are printed by
+`pigeons paths`.
+
+That machine-wide layer is what the service reads: a roost installed with
+`pigeons service install` runs as root, so it would otherwise never see the
+answer you gave as yourself. The install copies your answer there and prints
+what the service will do with it. To change the service's setting later, edit
+the machine-wide config and run `pigeons service restart`.
+
+pigeons never asks when it is not attached to a terminal, when it runs as
+`fly --stdio` (ssh's `ProxyCommand`), or when it runs elevated. Installing from
+a root shell instead of through `sudo` leaves nothing to trace an answer back
+to, so the service stays opted out until you set `telemetry_enabled` in the
+machine-wide config yourself.
+
 ## Commands
 
 ```bash
@@ -194,6 +231,7 @@ shall be dual licensed as above, without any additional terms or conditions.
 [QUIC]: https://en.wikipedia.org/wiki/QUIC
 [hole-punching]: https://en.wikipedia.org/wiki/Hole_punching_(networking)
 [iroh]: https://github.com/n0-computer/iroh
+[iroh-services]: https://services.iroh.computer
 [`ProxyCommand`]: https://man.openbsd.org/ssh_config#ProxyCommand
 [Releases]: https://github.com/n0-computer/pigeons/releases
 [Rust Docs]: https://docs.rs/iroh-pigeons

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,27 +21,21 @@ impl Config {
     /// machine-wide one. The service runs as root, where the per-user config is
     /// root's own and almost always absent.
     pub async fn load() -> Result<Self> {
-        let user_path = Self::config_path()?;
+        let user = Self::load_user().await?;
         let Ok(system_path) = Self::system_config_path() else {
-            return Self::load_from(&user_path).await;
+            return Ok(user);
         };
-        Self::load_with_fallback(&user_path, &system_path).await
+        let system = Self::load_from(&system_path).await?;
+
+        Ok(Self {
+            telemetry_enabled: user.telemetry_enabled.or(system.telemetry_enabled),
+        })
     }
 
     /// Loads only the per-user config. The first-run question is about this
     /// user's setting, so a machine-wide answer must not stand in for it.
     pub async fn load_user() -> Result<Self> {
         Self::load_from(&Self::config_path()?).await
-    }
-
-    async fn load_with_fallback(user_path: &Path, system_path: &Path) -> Result<Self> {
-        let mut config = Self::load_from(user_path).await?;
-        config.fill_unset_from(Self::load_from(system_path).await?);
-        Ok(config)
-    }
-
-    fn fill_unset_from(&mut self, fallback: Self) {
-        self.telemetry_enabled = self.telemetry_enabled.or(fallback.telemetry_enabled);
     }
 
     /// Read and parse the config at `path`. Loading is read-only: a config that
@@ -189,49 +183,6 @@ mod tests {
     #[test]
     fn empty_config() {
         let config = toml::from_str::<Config>("").unwrap();
-        assert_eq!(config.telemetry_enabled, None);
-    }
-
-    #[tokio::test]
-    async fn user_config_wins_over_the_machine_wide_one() {
-        let dir = tempfile::tempdir().unwrap();
-        let user = dir.path().join("user.toml");
-        let system = dir.path().join("system.toml");
-        fs::write(&user, "telemetry_enabled = false").await.unwrap();
-        fs::write(&system, "telemetry_enabled = true")
-            .await
-            .unwrap();
-
-        let config = Config::load_with_fallback(&user, &system).await.unwrap();
-
-        assert_eq!(config.telemetry_enabled, Some(false));
-    }
-
-    /// The case the service hits: root has no config of its own.
-    #[tokio::test]
-    async fn machine_wide_config_fills_in_an_unanswered_user_config() {
-        let dir = tempfile::tempdir().unwrap();
-        let system = dir.path().join("system.toml");
-        fs::write(&system, "telemetry_enabled = true")
-            .await
-            .unwrap();
-
-        let config = Config::load_with_fallback(&dir.path().join("absent.toml"), &system)
-            .await
-            .unwrap();
-
-        assert_eq!(config.telemetry_enabled, Some(true));
-    }
-
-    #[tokio::test]
-    async fn telemetry_stays_off_when_neither_layer_exists() {
-        let dir = tempfile::tempdir().unwrap();
-
-        let config =
-            Config::load_with_fallback(&dir.path().join("user.toml"), &dir.path().join("sys.toml"))
-                .await
-                .unwrap();
-
         assert_eq!(config.telemetry_enabled, None);
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,25 +12,11 @@ use tokio::{
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
-    telemetry_enabled: Option<bool>,
+    /// Whether to send metrics to iroh-services. `None` means we have not asked.
+    pub telemetry_enabled: Option<bool>,
 }
 
 impl Config {
-    /// Whether sending metrics to the embedded or configured iroh-services endpoint is enabled.
-    pub fn telemetry_enabled(&self) -> bool {
-        self.telemetry_enabled.unwrap_or(false)
-    }
-
-    /// Whether a telemetry choice has been recorded. An unset key means we
-    /// have never asked, which is not the same as an explicit `false`.
-    pub fn telemetry_configured(&self) -> bool {
-        self.telemetry_enabled.is_some()
-    }
-
-    pub fn set_telemetry_enabled(&mut self, enabled: bool) {
-        self.telemetry_enabled = Some(enabled);
-    }
-
     /// Loads the per-user config, taking any key it leaves unset from the
     /// machine-wide one. The service runs as root, where the per-user config is
     /// root's own and almost always absent.
@@ -166,7 +152,7 @@ pub async fn publish_telemetry_choice_for_service() -> Result<bool> {
 async fn publish_telemetry_choice_to(system_path: &Path, choice: Option<bool>) -> Result<bool> {
     if let Some(enabled) = choice {
         let mut system = Config::load_from(system_path).await.unwrap_or_default();
-        system.set_telemetry_enabled(enabled);
+        system.telemetry_enabled = Some(enabled);
         system.store_world_readable(system_path).await?;
     }
 
@@ -174,7 +160,8 @@ async fn publish_telemetry_choice_to(system_path: &Path, choice: Option<bool>) -
     Ok(Config::load_from(system_path)
         .await
         .unwrap_or_default()
-        .telemetry_enabled())
+        .telemetry_enabled
+        .unwrap_or(false))
 }
 
 /// The telemetry choice of the user who started an elevated command.
@@ -202,17 +189,7 @@ mod tests {
     #[test]
     fn empty_config() {
         let config = toml::from_str::<Config>("").unwrap();
-        assert!(!config.telemetry_enabled());
-    }
-
-    #[test]
-    fn declining_telemetry_still_counts_as_configured() {
-        let unasked = toml::from_str::<Config>("").unwrap();
-        assert!(!unasked.telemetry_configured());
-
-        let declined = toml::from_str::<Config>("telemetry_enabled = false").unwrap();
-        assert!(declined.telemetry_configured());
-        assert!(!declined.telemetry_enabled());
+        assert_eq!(config.telemetry_enabled, None);
     }
 
     #[tokio::test]
@@ -227,7 +204,7 @@ mod tests {
 
         let config = Config::load_with_fallback(&user, &system).await.unwrap();
 
-        assert!(!config.telemetry_enabled());
+        assert_eq!(config.telemetry_enabled, Some(false));
     }
 
     /// The case the service hits: root has no config of its own.
@@ -243,7 +220,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(config.telemetry_enabled());
+        assert_eq!(config.telemetry_enabled, Some(true));
     }
 
     #[tokio::test]
@@ -255,8 +232,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        assert!(!config.telemetry_configured());
-        assert!(!config.telemetry_enabled());
+        assert_eq!(config.telemetry_enabled, None);
     }
 
     #[tokio::test]
@@ -270,13 +246,8 @@ mod tests {
                 .unwrap();
 
             assert_eq!(effective, enabled);
-            assert_eq!(
-                Config::load_from(&system)
-                    .await
-                    .unwrap()
-                    .telemetry_enabled(),
-                enabled
-            );
+            let stored = Config::load_from(&system).await.unwrap();
+            assert_eq!(stored.telemetry_enabled, Some(enabled));
         }
     }
 
@@ -356,13 +327,13 @@ mod tests {
         let path = dir.path().join("nested").join("config.toml");
 
         for enabled in [true, false] {
-            let mut config = Config::default();
-            config.set_telemetry_enabled(enabled);
+            let config = Config {
+                telemetry_enabled: Some(enabled),
+            };
             config.store_to(&path).await.unwrap();
 
             let loaded = Config::load_from(&path).await.unwrap();
-            assert!(loaded.telemetry_configured());
-            assert_eq!(loaded.telemetry_enabled(), enabled);
+            assert_eq!(loaded.telemetry_enabled, Some(enabled));
         }
     }
 
@@ -375,7 +346,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(!config.telemetry_enabled());
+        assert_eq!(config.telemetry_enabled, None);
     }
 
     /// Regression: `load` used to open the file with `create(true)` and no write
@@ -389,8 +360,9 @@ mod tests {
 
         let config = Config::load_from(&path).await.unwrap();
 
-        assert!(
-            config.telemetry_enabled(),
+        assert_eq!(
+            config.telemetry_enabled,
+            Some(true),
             "settings on disk must take precedence over the defaults"
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::{
-    io,
+    env, io,
     path::{Path, PathBuf},
 };
 
@@ -21,8 +21,54 @@ impl Config {
         self.telemetry_enabled.unwrap_or(false)
     }
 
+    /// Whether the user has made a telemetry choice yet.
+    ///
+    /// An unset key means we have never asked, which is what the first-run
+    /// prompt keys off. It is distinct from an explicit `telemetry_enabled =
+    /// false`: both keep telemetry off, but only the former should produce a
+    /// question.
+    pub fn telemetry_configured(&self) -> bool {
+        self.telemetry_enabled.is_some()
+    }
+
+    /// Records a telemetry choice. Call [`Config::store`] to persist it.
+    pub fn set_telemetry_enabled(&mut self, enabled: bool) {
+        self.telemetry_enabled = Some(enabled);
+    }
+
+    /// Loads the config every pigeons run should use: the per-user config,
+    /// with any key it leaves unset taken from the machine-wide config.
+    ///
+    /// The layering exists for the service. A roost installed with `pigeons
+    /// service install` runs as root, whose per-user config is its own and
+    /// almost always absent, so the machine-wide file written at install time
+    /// is what carries the answer over.
     pub async fn load() -> Result<Self> {
+        let user_path = Self::config_path()?;
+        let Ok(system_path) = Self::system_config_path() else {
+            return Self::load_from(&user_path).await;
+        };
+        Self::load_with_fallback(&user_path, &system_path).await
+    }
+
+    /// Loads only the per-user config, ignoring the machine-wide fallback.
+    ///
+    /// The first-run question is about this user's setting, so it has to see
+    /// an unanswered user config as unanswered even on a machine that already
+    /// has a system-wide answer.
+    pub async fn load_user() -> Result<Self> {
         Self::load_from(&Self::config_path()?).await
+    }
+
+    async fn load_with_fallback(user_path: &Path, system_path: &Path) -> Result<Self> {
+        let mut config = Self::load_from(user_path).await?;
+        config.fill_unset_from(Self::load_from(system_path).await?);
+        Ok(config)
+    }
+
+    /// Takes every key this config leaves unset from `fallback`.
+    fn fill_unset_from(&mut self, fallback: Self) {
+        self.telemetry_enabled = self.telemetry_enabled.or(fallback.telemetry_enabled);
     }
 
     /// Read and parse the config at `path`. Loading is read-only: a config that
@@ -53,7 +99,10 @@ impl Config {
     }
 
     pub async fn store(&self) -> Result<()> {
-        let config_file_path = Self::config_path()?;
+        self.store_to(&Self::config_path()?).await
+    }
+
+    async fn store_to(&self, config_file_path: &Path) -> Result<()> {
         fs::create_dir_all(config_file_path.parent().expect("joined path")).await?;
 
         let mut file = File::options()
@@ -66,12 +115,113 @@ impl Config {
         Ok(())
     }
 
+    /// Writes the config to `path` and makes it readable by everyone.
+    ///
+    /// This is how the machine-wide config is written: every unprivileged run
+    /// reads it as a fallback, and the umask of the root shell doing the
+    /// installing would otherwise decide whether they can.
+    async fn store_world_readable(&self, path: &Path) -> Result<()> {
+        self.store_to(path).await?;
+
+        #[cfg(unix)]
+        {
+            use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+
+            let dir = path.parent().expect("joined path");
+            fs::set_permissions(dir, Permissions::from_mode(0o755)).await?;
+            fs::set_permissions(path, Permissions::from_mode(0o644)).await?;
+        }
+
+        Ok(())
+    }
+
     pub fn config_path() -> Result<PathBuf> {
         let config_dir = dirs::config_dir()
             .context("can't figure out config dir on this system")?
             .join("pigeons");
         Ok(config_dir.join("config.toml"))
     }
+
+    /// Path of the machine-wide config, alongside the endpoint ID the roost
+    /// publishes for `pigeons service status`.
+    pub fn system_config_path() -> Result<PathBuf> {
+        let dir = match env::consts::OS {
+            "linux" | "macos" => Path::new("/etc/pigeons"),
+            "windows" => Path::new("C:\\ProgramData\\pigeons"),
+            other => anyhow::bail!("no machine-wide config location on {other}"),
+        };
+        Ok(dir.join("config.toml"))
+    }
+
+    /// Path of the per-user config belonging to the owner of `home`.
+    ///
+    /// [`Config::config_path`] cannot answer this: it reports the location for
+    /// whoever is running, and an elevated install needs the location of the
+    /// user who started it. The layouts here mirror what `dirs` reports for a
+    /// default environment, which is the only thing we can know about another
+    /// account.
+    fn config_path_in(home: &Path) -> PathBuf {
+        let relative = match env::consts::OS {
+            "macos" => "Library/Application Support/pigeons/config.toml",
+            "windows" => "AppData/Roaming/pigeons/config.toml",
+            _ => ".config/pigeons/config.toml",
+        };
+        home.join(relative)
+    }
+}
+
+/// Copies the installing user's telemetry choice into the machine-wide config
+/// and reports what the service will do with it.
+///
+/// Call this from an elevated `pigeons service install`. The service runs as
+/// root and reads root's config, so without this step it can never see the
+/// answer the user gave in their own terminal.
+///
+/// # Errors
+///
+/// Returns an error when the machine-wide config cannot be written, which for
+/// an unprivileged caller it cannot.
+pub async fn publish_telemetry_choice_for_service() -> Result<bool> {
+    let system_path = Config::system_config_path()?;
+    let choice = installing_user_telemetry_choice().await;
+    publish_telemetry_choice_to(&system_path, choice).await
+}
+
+async fn publish_telemetry_choice_to(system_path: &Path, choice: Option<bool>) -> Result<bool> {
+    if let Some(enabled) = choice {
+        let mut system = Config::load_from(system_path).await.unwrap_or_default();
+        system.set_telemetry_enabled(enabled);
+        system.store_world_readable(system_path).await?;
+    }
+
+    // Report what is on disk rather than what we just wrote: with nothing to
+    // propagate, an answer an admin put there earlier still governs the service.
+    Ok(Config::load_from(system_path)
+        .await
+        .unwrap_or_default()
+        .telemetry_enabled())
+}
+
+/// The telemetry choice of the user who started an elevated command, if they
+/// have recorded one.
+///
+/// `sudo` leaves the original account in `SUDO_USER`, which is the only pointer
+/// an elevated unix process has back to the config of the person who answered
+/// the question. Windows elevation keeps the same account, so there the running
+/// user's own config is already the right one to read.
+async fn installing_user_telemetry_choice() -> Option<bool> {
+    let path = match env::var("SUDO_USER") {
+        Ok(user) => config_path_for_user(&user)?,
+        Err(_) => Config::config_path().ok()?,
+    };
+
+    Config::load_from(&path).await.ok()?.telemetry_enabled
+}
+
+/// Path of `user`'s config, or `None` when their home cannot be resolved.
+fn config_path_for_user(user: &str) -> Option<PathBuf> {
+    let home = homedir::home(user).ok()??;
+    Some(Config::config_path_in(&home))
 }
 
 #[cfg(test)]
@@ -82,6 +232,180 @@ mod tests {
     fn empty_config() {
         let config = toml::from_str::<Config>("").unwrap();
         assert!(!config.telemetry_enabled());
+    }
+
+    /// The first-run prompt asks exactly when no choice has been recorded, so
+    /// "off" and "never asked" have to stay distinguishable.
+    #[test]
+    fn declining_telemetry_still_counts_as_configured() {
+        let unasked = toml::from_str::<Config>("").unwrap();
+        assert!(!unasked.telemetry_configured());
+
+        let declined = toml::from_str::<Config>("telemetry_enabled = false").unwrap();
+        assert!(declined.telemetry_configured());
+        assert!(!declined.telemetry_enabled());
+    }
+
+    /// A user who answered the question owns the answer, even on a machine
+    /// whose service was installed with the opposite one.
+    #[tokio::test]
+    async fn user_config_wins_over_the_machine_wide_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let user = dir.path().join("user.toml");
+        let system = dir.path().join("system.toml");
+        fs::write(&user, "telemetry_enabled = false").await.unwrap();
+        fs::write(&system, "telemetry_enabled = true")
+            .await
+            .unwrap();
+
+        let config = Config::load_with_fallback(&user, &system).await.unwrap();
+
+        assert!(!config.telemetry_enabled());
+    }
+
+    /// This is the case the service hits: root has no config of its own, and
+    /// the answer lives in the machine-wide file written at install time.
+    #[tokio::test]
+    async fn machine_wide_config_fills_in_an_unanswered_user_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let system = dir.path().join("system.toml");
+        fs::write(&system, "telemetry_enabled = true")
+            .await
+            .unwrap();
+
+        let config = Config::load_with_fallback(&dir.path().join("absent.toml"), &system)
+            .await
+            .unwrap();
+
+        assert!(config.telemetry_enabled());
+    }
+
+    #[tokio::test]
+    async fn telemetry_stays_off_when_neither_layer_exists() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let config =
+            Config::load_with_fallback(&dir.path().join("user.toml"), &dir.path().join("sys.toml"))
+                .await
+                .unwrap();
+
+        assert!(!config.telemetry_configured());
+        assert!(!config.telemetry_enabled());
+    }
+
+    /// What `service install` does once elevated: the answer the user gave in
+    /// their own terminal becomes the setting the root-owned service reads.
+    #[tokio::test]
+    async fn publishing_a_choice_writes_the_machine_wide_config() {
+        for enabled in [true, false] {
+            let dir = tempfile::tempdir().unwrap();
+            let system = dir.path().join("pigeons").join("config.toml");
+
+            let effective = publish_telemetry_choice_to(&system, Some(enabled))
+                .await
+                .unwrap();
+
+            assert_eq!(effective, enabled);
+            assert_eq!(
+                Config::load_from(&system)
+                    .await
+                    .unwrap()
+                    .telemetry_enabled(),
+                enabled
+            );
+        }
+    }
+
+    /// Installing from a root shell leaves no `SUDO_USER` to trace back to, so
+    /// there is nothing to propagate and an answer already on the machine has
+    /// to survive the install.
+    #[tokio::test]
+    async fn publishing_nothing_keeps_the_existing_machine_wide_answer() {
+        let dir = tempfile::tempdir().unwrap();
+        let system = dir.path().join("config.toml");
+        fs::write(&system, "telemetry_enabled = true")
+            .await
+            .unwrap();
+
+        let effective = publish_telemetry_choice_to(&system, None).await.unwrap();
+
+        assert!(effective);
+    }
+
+    #[tokio::test]
+    async fn publishing_nothing_onto_a_bare_machine_leaves_the_service_opted_out() {
+        let dir = tempfile::tempdir().unwrap();
+        let system = dir.path().join("config.toml");
+
+        let effective = publish_telemetry_choice_to(&system, None).await.unwrap();
+
+        assert!(!effective);
+        assert!(!system.exists(), "nothing to record, nothing to write");
+    }
+
+    /// Root writes this file, everyone reads it, and root's umask does not get
+    /// a vote.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn machine_wide_config_is_world_readable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let system = dir.path().join("pigeons").join("config.toml");
+
+        publish_telemetry_choice_to(&system, Some(true))
+            .await
+            .unwrap();
+
+        let mode = fs::metadata(&system).await.unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o644);
+        let dir_mode = fs::metadata(system.parent().unwrap())
+            .await
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(dir_mode & 0o777, 0o755);
+    }
+
+    /// The elevated half of `service install` finds the invoking user's config
+    /// by way of their home directory, which has to resolve for a real account.
+    #[test]
+    fn config_path_for_user_lands_in_that_users_home() {
+        let me = whoami::username().expect("running as some user");
+
+        let path = config_path_for_user(&me).expect("current user has a home directory");
+
+        let home = homedir::my_home().unwrap().unwrap();
+        assert!(path.starts_with(&home), "{path:?} is not under {home:?}");
+        assert!(path.ends_with("pigeons/config.toml"), "{path:?}");
+    }
+
+    #[test]
+    fn config_path_in_a_home_matches_the_platform_layout() {
+        let path = Config::config_path_in(Path::new("/home/pigeon"));
+
+        let expected = match env::consts::OS {
+            "macos" => "/home/pigeon/Library/Application Support/pigeons/config.toml",
+            "windows" => "/home/pigeon/AppData/Roaming/pigeons/config.toml",
+            _ => "/home/pigeon/.config/pigeons/config.toml",
+        };
+        assert_eq!(path, Path::new(expected));
+    }
+
+    #[tokio::test]
+    async fn stored_telemetry_choice_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("config.toml");
+
+        for enabled in [true, false] {
+            let mut config = Config::default();
+            config.set_telemetry_enabled(enabled);
+            config.store_to(&path).await.unwrap();
+
+            let loaded = Config::load_from(&path).await.unwrap();
+            assert!(loaded.telemetry_configured());
+            assert_eq!(loaded.telemetry_enabled(), enabled);
+        }
     }
 
     /// Not having written a config yet is the normal case, not an error.

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,28 +21,19 @@ impl Config {
         self.telemetry_enabled.unwrap_or(false)
     }
 
-    /// Whether the user has made a telemetry choice yet.
-    ///
-    /// An unset key means we have never asked, which is what the first-run
-    /// prompt keys off. It is distinct from an explicit `telemetry_enabled =
-    /// false`: both keep telemetry off, but only the former should produce a
-    /// question.
+    /// Whether a telemetry choice has been recorded. An unset key means we
+    /// have never asked, which is not the same as an explicit `false`.
     pub fn telemetry_configured(&self) -> bool {
         self.telemetry_enabled.is_some()
     }
 
-    /// Records a telemetry choice. Call [`Config::store`] to persist it.
     pub fn set_telemetry_enabled(&mut self, enabled: bool) {
         self.telemetry_enabled = Some(enabled);
     }
 
-    /// Loads the config every pigeons run should use: the per-user config,
-    /// with any key it leaves unset taken from the machine-wide config.
-    ///
-    /// The layering exists for the service. A roost installed with `pigeons
-    /// service install` runs as root, whose per-user config is its own and
-    /// almost always absent, so the machine-wide file written at install time
-    /// is what carries the answer over.
+    /// Loads the per-user config, taking any key it leaves unset from the
+    /// machine-wide one. The service runs as root, where the per-user config is
+    /// root's own and almost always absent.
     pub async fn load() -> Result<Self> {
         let user_path = Self::config_path()?;
         let Ok(system_path) = Self::system_config_path() else {
@@ -51,11 +42,8 @@ impl Config {
         Self::load_with_fallback(&user_path, &system_path).await
     }
 
-    /// Loads only the per-user config, ignoring the machine-wide fallback.
-    ///
-    /// The first-run question is about this user's setting, so it has to see
-    /// an unanswered user config as unanswered even on a machine that already
-    /// has a system-wide answer.
+    /// Loads only the per-user config. The first-run question is about this
+    /// user's setting, so a machine-wide answer must not stand in for it.
     pub async fn load_user() -> Result<Self> {
         Self::load_from(&Self::config_path()?).await
     }
@@ -66,7 +54,6 @@ impl Config {
         Ok(config)
     }
 
-    /// Takes every key this config leaves unset from `fallback`.
     fn fill_unset_from(&mut self, fallback: Self) {
         self.telemetry_enabled = self.telemetry_enabled.or(fallback.telemetry_enabled);
     }
@@ -115,11 +102,8 @@ impl Config {
         Ok(())
     }
 
-    /// Writes the config to `path` and makes it readable by everyone.
-    ///
-    /// This is how the machine-wide config is written: every unprivileged run
-    /// reads it as a fallback, and the umask of the root shell doing the
-    /// installing would otherwise decide whether they can.
+    /// Writes the config to `path`, readable by everyone: unprivileged runs
+    /// read the machine-wide config, and root's umask does not get a vote.
     async fn store_world_readable(&self, path: &Path) -> Result<()> {
         self.store_to(path).await?;
 
@@ -143,7 +127,7 @@ impl Config {
     }
 
     /// Path of the machine-wide config, alongside the endpoint ID the roost
-    /// publishes for `pigeons service status`.
+    /// publishes there.
     pub fn system_config_path() -> Result<PathBuf> {
         let dir = match env::consts::OS {
             "linux" | "macos" => Path::new("/etc/pigeons"),
@@ -153,13 +137,9 @@ impl Config {
         Ok(dir.join("config.toml"))
     }
 
-    /// Path of the per-user config belonging to the owner of `home`.
-    ///
-    /// [`Config::config_path`] cannot answer this: it reports the location for
-    /// whoever is running, and an elevated install needs the location of the
-    /// user who started it. The layouts here mirror what `dirs` reports for a
-    /// default environment, which is the only thing we can know about another
-    /// account.
+    /// Path of the per-user config under `home`, for reading the config of a
+    /// user other than the one running. Assumes the default layout `dirs`
+    /// reports, which is all we can know about another account.
     fn config_path_in(home: &Path) -> PathBuf {
         let relative = match env::consts::OS {
             "macos" => "Library/Application Support/pigeons/config.toml",
@@ -171,16 +151,12 @@ impl Config {
 }
 
 /// Copies the installing user's telemetry choice into the machine-wide config
-/// and reports what the service will do with it.
-///
-/// Call this from an elevated `pigeons service install`. The service runs as
-/// root and reads root's config, so without this step it can never see the
-/// answer the user gave in their own terminal.
+/// and reports what the service will do with it. Call this from an elevated
+/// `pigeons service install`; the service reads root's config, not theirs.
 ///
 /// # Errors
 ///
-/// Returns an error when the machine-wide config cannot be written, which for
-/// an unprivileged caller it cannot.
+/// Returns an error when the machine-wide config cannot be written.
 pub async fn publish_telemetry_choice_for_service() -> Result<bool> {
     let system_path = Config::system_config_path()?;
     let choice = installing_user_telemetry_choice().await;
@@ -194,21 +170,17 @@ async fn publish_telemetry_choice_to(system_path: &Path, choice: Option<bool>) -
         system.store_world_readable(system_path).await?;
     }
 
-    // Report what is on disk rather than what we just wrote: with nothing to
-    // propagate, an answer an admin put there earlier still governs the service.
+    // With nothing to propagate, an answer already on the machine still stands.
     Ok(Config::load_from(system_path)
         .await
         .unwrap_or_default()
         .telemetry_enabled())
 }
 
-/// The telemetry choice of the user who started an elevated command, if they
-/// have recorded one.
+/// The telemetry choice of the user who started an elevated command.
 ///
-/// `sudo` leaves the original account in `SUDO_USER`, which is the only pointer
-/// an elevated unix process has back to the config of the person who answered
-/// the question. Windows elevation keeps the same account, so there the running
-/// user's own config is already the right one to read.
+/// `SUDO_USER` is the only pointer an elevated unix process has back to them.
+/// Windows elevation keeps the same account, so its own config is the right one.
 async fn installing_user_telemetry_choice() -> Option<bool> {
     let path = match env::var("SUDO_USER") {
         Ok(user) => config_path_for_user(&user)?,
@@ -218,7 +190,6 @@ async fn installing_user_telemetry_choice() -> Option<bool> {
     Config::load_from(&path).await.ok()?.telemetry_enabled
 }
 
-/// Path of `user`'s config, or `None` when their home cannot be resolved.
 fn config_path_for_user(user: &str) -> Option<PathBuf> {
     let home = homedir::home(user).ok()??;
     Some(Config::config_path_in(&home))
@@ -234,8 +205,6 @@ mod tests {
         assert!(!config.telemetry_enabled());
     }
 
-    /// The first-run prompt asks exactly when no choice has been recorded, so
-    /// "off" and "never asked" have to stay distinguishable.
     #[test]
     fn declining_telemetry_still_counts_as_configured() {
         let unasked = toml::from_str::<Config>("").unwrap();
@@ -246,8 +215,6 @@ mod tests {
         assert!(!declined.telemetry_enabled());
     }
 
-    /// A user who answered the question owns the answer, even on a machine
-    /// whose service was installed with the opposite one.
     #[tokio::test]
     async fn user_config_wins_over_the_machine_wide_one() {
         let dir = tempfile::tempdir().unwrap();
@@ -263,8 +230,7 @@ mod tests {
         assert!(!config.telemetry_enabled());
     }
 
-    /// This is the case the service hits: root has no config of its own, and
-    /// the answer lives in the machine-wide file written at install time.
+    /// The case the service hits: root has no config of its own.
     #[tokio::test]
     async fn machine_wide_config_fills_in_an_unanswered_user_config() {
         let dir = tempfile::tempdir().unwrap();
@@ -293,8 +259,6 @@ mod tests {
         assert!(!config.telemetry_enabled());
     }
 
-    /// What `service install` does once elevated: the answer the user gave in
-    /// their own terminal becomes the setting the root-owned service reads.
     #[tokio::test]
     async fn publishing_a_choice_writes_the_machine_wide_config() {
         for enabled in [true, false] {
@@ -316,9 +280,7 @@ mod tests {
         }
     }
 
-    /// Installing from a root shell leaves no `SUDO_USER` to trace back to, so
-    /// there is nothing to propagate and an answer already on the machine has
-    /// to survive the install.
+    /// Installing from a root shell leaves no `SUDO_USER` to trace back to.
     #[tokio::test]
     async fn publishing_nothing_keeps_the_existing_machine_wide_answer() {
         let dir = tempfile::tempdir().unwrap();
@@ -343,8 +305,6 @@ mod tests {
         assert!(!system.exists(), "nothing to record, nothing to write");
     }
 
-    /// Root writes this file, everyone reads it, and root's umask does not get
-    /// a vote.
     #[cfg(unix)]
     #[tokio::test]
     async fn machine_wide_config_is_world_readable() {
@@ -367,8 +327,6 @@ mod tests {
         assert_eq!(dir_mode & 0o777, 0o755);
     }
 
-    /// The elevated half of `service install` finds the invoking user's config
-    /// by way of their home directory, which has to resolve for a real account.
     #[test]
     fn config_path_for_user_lands_in_that_users_home() {
         let me = whoami::username().expect("running as some user");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod service;
 mod ssh;
 mod tunnel;
 
-pub use config::Config;
+pub use config::{Config, publish_telemetry_choice_for_service};
 pub use service::{
     Service, ServiceParams, install as install_service, resolve_binary_path,
     restart as restart_service, service_endpoint_id, service_log, uninstall as uninstall_service,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,7 @@ use tokio::{
 
 const RELAY_URL_HELP: &str = "use this relay server, replacing the defaults (repeatable)";
 
-/// What we tell people before asking them about telemetry, kept to what the
-/// iroh-services client actually reports: counters from the iroh endpoint.
+/// Kept to what the iroh-services client actually reports: endpoint counters.
 const TELEMETRY_PITCH: &str = "\
 pigeons can send anonymous metrics to help us develop iroh, the peer-to-peer
 network it flies over. They are connection counters: relay usage,
@@ -137,13 +136,10 @@ pub struct RemoveArgs {
 }
 
 /// Whether this invocation is one we can interrupt with the telemetry question.
-///
-/// The question is only worth asking of a person sitting at a terminal who is
-/// setting pigeons up, and it is actively harmful to ask it anywhere else.
+/// Only a person setting pigeons up at a terminal should ever see it.
 fn should_ask_about_telemetry(cmd: &Cmd) -> bool {
     let setup_command = match cmd {
-        // `fly --stdio` is ssh's ProxyCommand: stdin and stdout carry the
-        // tunnel, so a prompt on either would corrupt the session.
+        // `fly --stdio` is ssh's ProxyCommand: a prompt would corrupt the tunnel.
         Cmd::Fly(args) => !args.stdio,
         Cmd::Roost(_) | Cmd::Add(_) => true,
         Cmd::Service {
@@ -152,19 +148,16 @@ fn should_ask_about_telemetry(cmd: &Cmd) -> bool {
         _ => false,
     };
 
-    // Elevated runs would write the answer into root's config rather than the
-    // config of the person answering. `service install` re-runs itself elevated,
-    // and by then the unelevated half has already asked.
+    // An elevated run would write the answer into root's config, and the
+    // unelevated half of `service install` has already asked by then.
     setup_command
         && !self_runas::is_elevated()
         && io::stdin().is_terminal()
         && io::stderr().is_terminal()
 }
 
-/// Reads a yes or no answer from `input`, re-asking until it gets one.
-///
-/// An empty line takes `default`. Returns `None` at end of input: a closed
-/// stdin never answered the question, which is not the same as answering no.
+/// Reads a yes or no answer from `input`, re-asking until it gets one. An empty
+/// line takes `default`; end of input returns `None`, which is not a no.
 async fn read_yes_no<R: AsyncBufRead + Unpin>(
     input: &mut R,
     default: bool,
@@ -184,13 +177,9 @@ async fn read_yes_no<R: AsyncBufRead + Unpin>(
     }
 }
 
-/// Asks about telemetry the first time someone sets pigeons up, and records
-/// the answer so we never ask again.
-///
-/// Both answers are written to the config file, which is what makes this a
-/// one-time question: an unset key means unasked, not declined. Every failure
-/// here is swallowed, because failing to record a preference must not stop the
-/// command the user actually ran.
+/// Asks about telemetry the first time someone sets pigeons up. Both answers
+/// are recorded, which is what makes it a one-time question. Failures are
+/// swallowed: a preference we cannot record must not stop the command itself.
 async fn ask_about_telemetry_once(cmd: &Cmd) {
     if !should_ask_about_telemetry(cmd) {
         return;
@@ -199,9 +188,7 @@ async fn ask_about_telemetry_once(cmd: &Cmd) {
         return;
     };
     // Deliberately not `load_or_default`: a config we could not parse is one we
-    // must not overwrite with an answer about its own contents. The user layer
-    // is read on its own so a machine-wide answer cannot silently stand in for
-    // this user's.
+    // must not overwrite.
     let Ok(mut config) = Config::load_user().await else {
         return;
     };
@@ -210,12 +197,10 @@ async fn ask_about_telemetry_once(cmd: &Cmd) {
     }
 
     eprintln!("\n{TELEMETRY_PITCH}\n");
-    // Opting in takes a deliberate "y": someone who hits enter to get past the
-    // question has not agreed to anything.
     eprint!("Send anonymous metrics? [y/N] ");
     let enabled = match read_yes_no(&mut BufReader::new(async_io::stdin()), false).await {
         Ok(Some(enabled)) => enabled,
-        // Leave the config alone so the next interactive run asks again.
+        // No answer: leave the config alone so the next run asks again.
         Ok(None) => {
             eprintln!();
             return;
@@ -239,13 +224,9 @@ async fn ask_about_telemetry_once(cmd: &Cmd) {
     }
 }
 
-/// Carries the installing user's telemetry choice over to the service and says
-/// what the service will do.
-///
-/// The service reads root's config rather than the config of whoever installed
-/// it, so the choice has to be copied into the machine-wide file. A failure
-/// here leaves the service opted out, which is worth a line of output but not
-/// worth failing an otherwise successful install over.
+/// Carries the installing user's telemetry choice over to the service, which
+/// reads root's config rather than theirs. A failure here leaves the service
+/// opted out, which is not worth failing a successful install over.
 async fn report_service_telemetry() {
     let enabled = match publish_telemetry_choice_for_service().await {
         Ok(enabled) => enabled,
@@ -532,8 +513,6 @@ mod tests {
         assert_eq!(answer("maybe\nsure\nn\n", true).await, Some(false));
     }
 
-    /// A closed stdin never answered, so the caller has to leave the config
-    /// untouched and ask again next time rather than record a silent no.
     #[tokio::test]
     async fn read_yes_no_returns_none_at_end_of_input() {
         assert_eq!(answer("", true).await, None);
@@ -550,8 +529,7 @@ mod tests {
         assert!(!should_ask_about_telemetry(&stdio));
     }
 
-    /// Reporting commands are not a setup step, so they stay quiet even on a
-    /// terminal.
+    /// Reporting commands are not a setup step.
     #[test]
     fn telemetry_question_skips_read_only_commands() {
         assert!(!should_ask_about_telemetry(&Cmd::List));

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ const RELAY_URL_HELP: &str = "use this relay server, replacing the defaults (rep
 /// Kept to what the iroh-services client actually reports: endpoint counters.
 const TELEMETRY_PITCH: &str = "\
 pigeons can send anonymous metrics to help us develop iroh, the peer-to-peer
-network it flies over. They are connection counters: relay usage,
+network it flies over. They are counts of: relay usage,
 hole-punching success, bytes moved. No hostnames, no usernames, no SSH
 traffic, and nothing about the machines you connect to.";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,31 @@
-use std::{io, path::Path, str::FromStr};
+use std::{
+    io::{self, IsTerminal},
+    path::Path,
+    str::FromStr,
+};
 
 use clap::{ArgAction, Args, Parser, Subcommand};
 use iroh::{EndpointId, RelayUrl};
 use iroh_pigeons::{
     Config, RoostConfig, ServiceParams, Tunnel, add_tunnel_host, home_ssh_dir, install_service,
-    list_tunnel_hosts, remove_tunnel_host, resolve_binary_path, restart_service,
-    service_endpoint_id, service_log, uninstall_service,
+    list_tunnel_hosts, publish_telemetry_choice_for_service, remove_tunnel_host,
+    resolve_binary_path, restart_service, service_endpoint_id, service_log, uninstall_service,
 };
-use tokio::{fs, signal};
+use tokio::{
+    fs,
+    io::{self as async_io, AsyncBufRead, AsyncBufReadExt, BufReader},
+    signal,
+};
 
 const RELAY_URL_HELP: &str = "use this relay server, replacing the defaults (repeatable)";
+
+/// What we tell people before asking them about telemetry, kept to what the
+/// iroh-services client actually reports: counters from the iroh endpoint.
+const TELEMETRY_PITCH: &str = "\
+pigeons can send anonymous metrics to help us develop iroh, the peer-to-peer
+network it flies over. They are connection counters: relay usage,
+hole-punching success, bytes moved. No hostnames, no usernames, no SSH
+traffic, and nothing about the machines you connect to.";
 
 /// Derive a route name from an endpoint ID for when `--name` is omitted.
 ///
@@ -120,6 +136,139 @@ pub struct RemoveArgs {
     pub name: String,
 }
 
+/// Whether this invocation is one we can interrupt with the telemetry question.
+///
+/// The question is only worth asking of a person sitting at a terminal who is
+/// setting pigeons up, and it is actively harmful to ask it anywhere else.
+fn should_ask_about_telemetry(cmd: &Cmd) -> bool {
+    let setup_command = match cmd {
+        // `fly --stdio` is ssh's ProxyCommand: stdin and stdout carry the
+        // tunnel, so a prompt on either would corrupt the session.
+        Cmd::Fly(args) => !args.stdio,
+        Cmd::Roost(_) | Cmd::Add(_) => true,
+        Cmd::Service {
+            op: ServiceCmd::Install { .. },
+        } => true,
+        _ => false,
+    };
+
+    // Elevated runs would write the answer into root's config rather than the
+    // config of the person answering. `service install` re-runs itself elevated,
+    // and by then the unelevated half has already asked.
+    setup_command
+        && !self_runas::is_elevated()
+        && io::stdin().is_terminal()
+        && io::stderr().is_terminal()
+}
+
+/// Reads a yes or no answer from `input`, re-asking until it gets one.
+///
+/// An empty line takes `default`. Returns `None` at end of input: a closed
+/// stdin never answered the question, which is not the same as answering no.
+async fn read_yes_no<R: AsyncBufRead + Unpin>(
+    input: &mut R,
+    default: bool,
+) -> io::Result<Option<bool>> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if input.read_line(&mut line).await? == 0 {
+            return Ok(None);
+        }
+        match line.trim().to_ascii_lowercase().as_str() {
+            "" => return Ok(Some(default)),
+            "y" | "yes" => return Ok(Some(true)),
+            "n" | "no" => return Ok(Some(false)),
+            _ => eprint!("please answer 'y' or 'n': "),
+        }
+    }
+}
+
+/// Asks about telemetry the first time someone sets pigeons up, and records
+/// the answer so we never ask again.
+///
+/// Both answers are written to the config file, which is what makes this a
+/// one-time question: an unset key means unasked, not declined. Every failure
+/// here is swallowed, because failing to record a preference must not stop the
+/// command the user actually ran.
+async fn ask_about_telemetry_once(cmd: &Cmd) {
+    if !should_ask_about_telemetry(cmd) {
+        return;
+    }
+    let Ok(config_path) = Config::config_path() else {
+        return;
+    };
+    // Deliberately not `load_or_default`: a config we could not parse is one we
+    // must not overwrite with an answer about its own contents. The user layer
+    // is read on its own so a machine-wide answer cannot silently stand in for
+    // this user's.
+    let Ok(mut config) = Config::load_user().await else {
+        return;
+    };
+    if config.telemetry_configured() {
+        return;
+    }
+
+    eprintln!("\n{TELEMETRY_PITCH}\n");
+    // Opting in takes a deliberate "y": someone who hits enter to get past the
+    // question has not agreed to anything.
+    eprint!("Send anonymous metrics? [y/N] ");
+    let enabled = match read_yes_no(&mut BufReader::new(async_io::stdin()), false).await {
+        Ok(Some(enabled)) => enabled,
+        // Leave the config alone so the next interactive run asks again.
+        Ok(None) => {
+            eprintln!();
+            return;
+        }
+        Err(err) => {
+            tracing::warn!("failed reading telemetry answer: {err:#}");
+            return;
+        }
+    };
+
+    config.set_telemetry_enabled(enabled);
+    if let Err(err) = config.store().await {
+        eprintln!("could not save your answer: {err:#}\n");
+        return;
+    }
+    let path = config_path.display();
+    if enabled {
+        eprintln!("\nThanks! Set telemetry_enabled = false in {path} to turn metrics off.\n");
+    } else {
+        eprintln!("\nNo metrics will be sent. Set telemetry_enabled = true in {path} to opt in.\n");
+    }
+}
+
+/// Carries the installing user's telemetry choice over to the service and says
+/// what the service will do.
+///
+/// The service reads root's config rather than the config of whoever installed
+/// it, so the choice has to be copied into the machine-wide file. A failure
+/// here leaves the service opted out, which is worth a line of output but not
+/// worth failing an otherwise successful install over.
+async fn report_service_telemetry() {
+    let enabled = match publish_telemetry_choice_for_service().await {
+        Ok(enabled) => enabled,
+        Err(err) => {
+            println!("Could not record a telemetry setting for the service: {err:#}");
+            false
+        }
+    };
+
+    let path = Config::system_config_path()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "the machine-wide config".to_string());
+    if enabled {
+        println!(
+            "Anonymous metrics: on for the service. Set telemetry_enabled = false in {path} to turn them off."
+        );
+    } else {
+        println!(
+            "Anonymous metrics: off for the service. Set telemetry_enabled = true in {path} to opt in."
+        );
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
@@ -128,6 +277,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let cli = Cli::parse();
+    ask_about_telemetry_once(&cli.cmd).await;
 
     match cli.cmd {
         Cmd::Roost(args) => {
@@ -259,6 +409,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Cmd::Paths => {
             println!("config: {:?}", Config::config_path()?);
+            if let Ok(system_config) = Config::system_config_path() {
+                println!("system config: {system_config:?}");
+            }
             let ssh_dir = home_ssh_dir()?;
             let pub_key = ssh_dir.join("pigeons_ed25519.pub");
             let priv_key = ssh_dir.join("pigeons_ed25519");
@@ -288,6 +441,7 @@ async fn main() -> anyhow::Result<()> {
                     })
                     .await?;
                     println!("Pigeons service installed.");
+                    report_service_telemetry().await;
                     Ok(())
                 }
                 ServiceCmd::Uninstall => {
@@ -351,6 +505,61 @@ mod tests {
     fn default_route_name_handles_short_ids() {
         assert_eq!(default_route_name("abc"), "pigeon-abc");
         assert_eq!(default_route_name(""), "pigeon-");
+    }
+
+    async fn answer(input: &str, default: bool) -> Option<bool> {
+        read_yes_no(&mut BufReader::new(input.as_bytes()), default)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn read_yes_no_accepts_both_spellings_in_any_case() {
+        assert_eq!(answer("y\n", false).await, Some(true));
+        assert_eq!(answer("YES\n", false).await, Some(true));
+        assert_eq!(answer("  n  \n", true).await, Some(false));
+        assert_eq!(answer("No\n", true).await, Some(false));
+    }
+
+    #[tokio::test]
+    async fn read_yes_no_takes_the_default_on_a_bare_newline() {
+        assert_eq!(answer("\n", true).await, Some(true));
+        assert_eq!(answer("\n", false).await, Some(false));
+    }
+
+    #[tokio::test]
+    async fn read_yes_no_reprompts_until_the_answer_parses() {
+        assert_eq!(answer("maybe\nsure\nn\n", true).await, Some(false));
+    }
+
+    /// A closed stdin never answered, so the caller has to leave the config
+    /// untouched and ask again next time rather than record a silent no.
+    #[tokio::test]
+    async fn read_yes_no_returns_none_at_end_of_input() {
+        assert_eq!(answer("", true).await, None);
+        assert_eq!(answer("maybe\n", true).await, None);
+    }
+
+    #[test]
+    fn telemetry_question_skips_ssh_proxy_command() {
+        let stdio = Cmd::Fly(FlyArgs {
+            public_key: "abc".to_string(),
+            stdio: true,
+            relay_url: vec![],
+        });
+        assert!(!should_ask_about_telemetry(&stdio));
+    }
+
+    /// Reporting commands are not a setup step, so they stay quiet even on a
+    /// terminal.
+    #[test]
+    fn telemetry_question_skips_read_only_commands() {
+        assert!(!should_ask_about_telemetry(&Cmd::List));
+        assert!(!should_ask_about_telemetry(&Cmd::Version));
+        assert!(!should_ask_about_telemetry(&Cmd::Paths));
+        assert!(!should_ask_about_telemetry(&Cmd::Service {
+            op: ServiceCmd::Status
+        }));
     }
 
     /// Regression: the ID is not validated until after the name is derived, so

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,7 @@ async fn ask_about_telemetry_once(cmd: &Cmd) {
     let Ok(mut config) = Config::load_user().await else {
         return;
     };
-    if config.telemetry_configured() {
+    if config.telemetry_enabled.is_some() {
         return;
     }
 
@@ -211,7 +211,7 @@ async fn ask_about_telemetry_once(cmd: &Cmd) {
         }
     };
 
-    config.set_telemetry_enabled(enabled);
+    config.telemetry_enabled = Some(enabled);
     if let Err(err) = config.store().await {
         eprintln!("could not save your answer: {err:#}\n");
         return;

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -270,7 +270,7 @@ where
 }
 
 fn iroh_services_api_secret(config: &Config) -> Result<Option<ApiSecret>> {
-    if !config.telemetry_enabled() {
+    if !config.telemetry_enabled.unwrap_or(false) {
         return Ok(None);
     }
 


### PR DESCRIPTION
`telemetry_enabled` has been in the config since the iroh-services client landed, but nothing ever set it. Metrics were off for everyone, and opting in meant hand-writing a TOML file most people would never find.

## What this does

The first setup command run at a terminal (`roost`, `fly`, `add`, or `service install`) asks once:

```
pigeons can send anonymous metrics to help us develop iroh, the peer-to-peer
network it flies over. They are connection counters: relay usage,
hole-punching success, bytes moved. No hostnames, no usernames, no SSH
traffic, and nothing about the machines you connect to.

Send anonymous metrics? [y/N]
```

Both answers are written to the per-user config, which is what makes this a one-time question: an unset key means unasked, an explicit `false` means declined. Opting in takes a typed `y`, so hitting enter to get past the question agrees to nothing. The confirmation names the config file so the answer is easy to revisit.

Nothing is asked of `fly --stdio` (ssh's `ProxyCommand`, where stdin and stdout carry the tunnel), of anything not attached to a terminal, or of an elevated run.

## Reaching the service

A per-user answer alone never reaches the service: a roost installed with `pigeons service install` runs as root and reads root's config. So config loading now has two layers. The per-user file wins, and any key it leaves unset is taken from a machine-wide config at `/etc/pigeons/config.toml` (`C:\ProgramData\pigeons\config.toml` on Windows), next to the `endpoint_id` the roost already publishes there. The existing uninstall scripts `rm -rf /etc/pigeons`, so it is cleaned up already.

The elevated half of `service install` copies the installing user's answer into that file and prints what the service will do with it. Elevation goes through `sudo` on both Linux and macOS whenever a TTY is present, so `SUDO_USER` points back at the person who answered; Windows UAC keeps the same account, so it reads its own config. No new CLI flags, and no new `sudo` requirement: the write happens inside elevation `service install` already performs.

Installing from a root shell rather than through `sudo` leaves nothing to trace an answer back to. That case propagates nothing and leaves the service opted out rather than guessing.

The first-run question deliberately reads the user layer alone. A machine-wide `true` set by whoever installed the service does not silence the question for other users on that box, and their own answer overrides it: the layer is a default, not a gag.

## Testing

32 tests pass, clippy and rustfmt clean. New coverage: answer parsing (spellings, default, re-prompt, EOF), which commands may ask, user-over-system precedence, system-fills-unset (the service's case), propagation of both `true` and `false`, a root-shell install preserving an existing machine-wide answer and writing nothing onto a bare machine, `0644`/`0755` modes on the machine-wide file, and `SUDO_USER` to config-path resolution.

The prompt was driven through a real pty for each path: yes, no, bare enter, garbage then an answer, second run silent, non-terminal silent, and `fly --stdio` silent on a terminal.

Two limits worth naming. The propagation path is tested against a tempdir rather than a live `sudo` install, since that registers a real daemon; `sudo pigeons service install` followed by `cat /etc/pigeons/config.toml` is the live check. And resolving another user's config assumes the default layout under their home, so a Linux user with a non-default `XDG_CONFIG_HOME` is not found: that propagates nothing and the service stays opted out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RfGQU4XtP8LgQDePpCzMJ