### PR TITLE
Fix server-first SSH stream establishment and half-close draining

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -2,9 +2,12 @@ use iroh::{
     endpoint::Connection,
     protocol::{AcceptError, ProtocolHandler},
 };
-use tokio::net::TcpStream;
+use tokio::{
+    io::{AsyncRead, AsyncReadExt},
+    net::TcpStream,
+};
 
-use crate::tunnel::copy_flush;
+use crate::tunnel::copy_both;
 
 #[derive(Debug)]
 pub(crate) struct PigeonsProtocol {
@@ -12,7 +15,8 @@ pub(crate) struct PigeonsProtocol {
 }
 
 impl PigeonsProtocol {
-    pub(crate) const ALPN: &[u8] = b"/pigeons/0";
+    pub(crate) const ALPN: &[u8] = b"/pigeons/1";
+    pub(crate) const STREAM_PREFACE: [u8; 1] = [0];
 
     /// create a new pigeons "home" that will forward incoming connections from
     /// a bound endpoint to the given local ssh server port
@@ -28,6 +32,10 @@ impl ProtocolHandler for PigeonsProtocol {
         match connection.accept_bi().await {
             Ok((mut iroh_send, mut iroh_recv)) => {
                 tracing::info!("pigeon arrived from {endpoint_id}");
+                if let Err(error) = read_stream_preface(&mut iroh_recv).await {
+                    tracing::error!("pigeon from {endpoint_id} had an invalid preface: {error}");
+                    return Ok(());
+                }
 
                 match TcpStream::connect(format!("127.0.0.1:{}", self.ssh_port)).await {
                     Ok(ssh_stream) => {
@@ -36,19 +44,22 @@ impl ProtocolHandler for PigeonsProtocol {
 
                         let (mut local_read, mut local_write) = ssh_stream.into_split();
 
-                        let a_to_b = copy_flush(&mut local_read, &mut iroh_send);
-                        let b_to_a = copy_flush(&mut iroh_recv, &mut local_write);
-
-                        tokio::select! {
-                            result = a_to_b => {
-                                let _ = result;
-                                tracing::info!("pigeon from {endpoint_id} returned home");
-                            },
-                            result = b_to_a => {
-                                let _ = result;
-                                tracing::info!("pigeon from {endpoint_id} returned home");
-                            },
-                        };
+                        if let Err(error) = copy_both(
+                            &mut local_read,
+                            &mut local_write,
+                            &mut iroh_recv,
+                            &mut iroh_send,
+                        )
+                        .await
+                        {
+                            tracing::error!("pigeon from {endpoint_id} failed in transit: {error}");
+                        }
+                        if let Err(error) = iroh_send.stopped().await {
+                            tracing::debug!(
+                                "pigeon from {endpoint_id} closed before delivery acknowledgement: {error}"
+                            );
+                        }
+                        tracing::info!("pigeon from {endpoint_id} returned home");
                     }
                     Err(e) => {
                         tracing::error!("pigeon couldn't reach sshd: {e}");
@@ -61,5 +72,111 @@ impl ProtocolHandler for PigeonsProtocol {
         }
 
         Ok(())
+    }
+}
+
+async fn read_stream_preface<R>(reader: &mut R) -> std::io::Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut preface = [0; PigeonsProtocol::STREAM_PREFACE.len()];
+    reader.read_exact(&mut preface).await?;
+    if preface != PigeonsProtocol::STREAM_PREFACE {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "invalid pigeons stream preface",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tunnel::{RoostConfig, Tunnel};
+    use iroh::RelayUrl;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn stream_preface_is_required_and_consumed() {
+        let (mut writer, mut reader) = tokio::io::duplex(16);
+        writer
+            .write_all(&PigeonsProtocol::STREAM_PREFACE)
+            .await
+            .unwrap();
+        writer.write_all(b"SSH-").await.unwrap();
+        read_stream_preface(&mut reader).await.unwrap();
+        let mut banner = [0; 4];
+        reader.read_exact(&mut banner).await.unwrap();
+        assert_eq!(&banner, b"SSH-");
+
+        let (mut writer, mut reader) = tokio::io::duplex(1);
+        writer.write_all(&[1]).await.unwrap();
+        assert_eq!(
+            read_stream_preface(&mut reader).await.unwrap_err().kind(),
+            std::io::ErrorKind::InvalidData
+        );
+    }
+
+    #[tokio::test]
+    async fn clean_remote_close_is_observed_as_stream_eof() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let ssh_port = listener.local_addr().unwrap().port();
+        let service = tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                if socket.write_all(b"SSH-2.0-pigeons-test\r\n").await.is_err() {
+                    continue;
+                }
+                let mut request = Vec::new();
+                if socket.read_to_end(&mut request).await.is_err() {
+                    continue;
+                }
+                if request == b"half-close-payload" {
+                    socket.write_all(b"DRAINED").await.unwrap();
+                    socket.shutdown().await.unwrap();
+                    break;
+                }
+            }
+        });
+
+        let relay: RelayUrl = "http://127.0.0.1:9".parse().unwrap();
+        let mut server_builder = Tunnel::builder_ephemeral().await.unwrap();
+        server_builder.roost = Some(RoostConfig { ssh_port });
+        server_builder.relay_urls = vec![relay.clone()];
+        let server = server_builder.build().await.unwrap();
+        let server_addr = server.endpoint().addr();
+        assert!(server_addr.ip_addrs().next().is_some());
+
+        let mut client_builder = Tunnel::builder_ephemeral().await.unwrap();
+        client_builder.relay_urls = vec![relay];
+        let client = client_builder.build().await.unwrap();
+        let connection = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            client
+                .endpoint()
+                .connect(server_addr, PigeonsProtocol::ALPN),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let (mut send, mut receive) = connection.open_bi().await.unwrap();
+        send.write_all(&PigeonsProtocol::STREAM_PREFACE)
+            .await
+            .unwrap();
+        send.write_all(b"half-close-payload").await.unwrap();
+        send.shutdown().await.unwrap();
+
+        let response =
+            tokio::time::timeout(std::time::Duration::from_secs(10), receive.read_to_end(128))
+                .await
+                .expect("remote response should finish")
+                .expect("clean peer close must be stream EOF");
+        assert_eq!(response, b"SSH-2.0-pigeons-test\r\nDRAINED");
+
+        service.await.unwrap();
+        client.close().await.unwrap();
+        server.close().await.unwrap();
     }
 }

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -153,18 +153,16 @@ impl Tunnel {
             .await?;
         tracing::debug!("fly_stdio: connected, opening bidirectional stream");
         let (mut iroh_send, mut iroh_recv) = conn.open_bi().await?;
+        iroh_send
+            .write_all(&PigeonsProtocol::STREAM_PREFACE)
+            .await?;
+        iroh_send.flush().await?;
         tracing::debug!("fly_stdio: bridging stdin/stdout");
 
         let mut stdin = io::stdin();
         let mut stdout = io::stdout();
 
-        let stdin_to_iroh = copy_flush(&mut stdin, &mut iroh_send);
-        let iroh_to_stdout = copy_flush(&mut iroh_recv, &mut stdout);
-
-        tokio::select! {
-            result = stdin_to_iroh => { result?; }
-            result = iroh_to_stdout => { result?; }
-        }
+        copy_both(&mut stdin, &mut stdout, &mut iroh_recv, &mut iroh_send).await?;
 
         Ok(())
     }
@@ -230,21 +228,49 @@ async fn bridge_connection(
     let conn = endpoint.connect(remote_id, PigeonsProtocol::ALPN).await?;
     tracing::debug!("bridge_connection: connected, opening bi stream");
     let (mut iroh_send, mut iroh_recv) = conn.open_bi().await?;
+    iroh_send
+        .write_all(&PigeonsProtocol::STREAM_PREFACE)
+        .await?;
+    iroh_send.flush().await?;
     let (mut tcp_read, mut tcp_write) = tcp_stream.into_split();
 
-    let tcp_to_iroh = copy_flush(&mut tcp_read, &mut iroh_send);
-    let iroh_to_tcp = copy_flush(&mut iroh_recv, &mut tcp_write);
-
-    tokio::select! {
-        result = tcp_to_iroh => {
-            let _ = result;
-        }
-        result = iroh_to_tcp => {
-            let _ = result;
-        }
-    }
+    copy_both(
+        &mut tcp_read,
+        &mut tcp_write,
+        &mut iroh_recv,
+        &mut iroh_send,
+    )
+    .await?;
 
     Ok(())
+}
+
+pub(crate) async fn copy_both<AR, AW, BR, BW>(
+    a_reader: &mut AR,
+    a_writer: &mut AW,
+    b_reader: &mut BR,
+    b_writer: &mut BW,
+) -> io::Result<(u64, u64)>
+where
+    AR: AsyncRead + Unpin,
+    AW: AsyncWrite + Unpin,
+    BR: AsyncRead + Unpin,
+    BW: AsyncWrite + Unpin,
+{
+    tokio::try_join!(
+        copy_flush_and_shutdown(a_reader, b_writer),
+        copy_flush_and_shutdown(b_reader, a_writer),
+    )
+}
+
+async fn copy_flush_and_shutdown<R, W>(reader: &mut R, writer: &mut W) -> io::Result<u64>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let copied = copy_flush(reader, writer).await?;
+    writer.shutdown().await?;
+    Ok(copied)
 }
 
 /// Copy data from reader to writer, flushing after every write.


### PR DESCRIPTION
## Summary
- send and validate a one-byte stream preface so QUIC bi streams are established before server-first SSH banners
- propagate EOF as a half-close while continuing to drain the opposite direction
- wait for the peer acknowledgement before ending the roost handler
- version the breaking wire contract as `/pigeons/1`

## Why this belongs in pigeons
These behaviors sit inside the QUIC stream and TCP bridge. A subprocess wrapper cannot write an internal stream preface, propagate per-direction shutdown, or keep the protocol handler alive until peer acknowledgement.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked`
- regression test for server-first SSH banner plus request half-close and drained response
- invalid preface rejection

## Compatibility
This intentionally rejects mixed `/pigeons/0` and `/pigeons/1` peers instead of silently consuming application bytes. Both sides must upgrade together.