### PR TITLE
Support persistent client identities and explicit endpoint addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ machine-wide config yourself.
 # Client
 > pigeons fly <ENDPOINT_ID>                 # quick connect (binds local port)
 > pigeons fly --stdio <ENDPOINT_ID>         # ProxyCommand mode (used by ssh config)
+> pigeons endpoint-id --key-dir <DIR>       # create/read a persistent client identity
+> pigeons fly --key-dir <DIR> <ENDPOINT_ID> # reuse that client identity
+> pigeons fly --relay-url <URL> --direct-address <IP:PORT> <ENDPOINT_ID>
 > pigeons add --id <ID> --name <NAME>       # add SSH config entry
 > pigeons list                              # list pigeon routes
 > pigeons remove <NAME>                     # remove SSH config entry

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,6 @@ pub use service::{
 };
 pub use ssh::{
     SshConfigPigeonEntry, add_tunnel_host, dot_ssh_secret_key, home_ssh_dir, list_tunnel_hosts,
-    remove_tunnel_host,
+    persistent_endpoint_id, remove_tunnel_host,
 };
 pub use tunnel::{RoostConfig, Tunnel, TunnelBuilder};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,17 @@
 use std::{
     io::{self, IsTerminal},
-    path::Path,
+    net::SocketAddr,
+    path::{Path, PathBuf},
     str::FromStr,
 };
 
 use clap::{ArgAction, Args, Parser, Subcommand};
-use iroh::{EndpointId, RelayUrl};
+use iroh::{EndpointAddr, EndpointId, RelayUrl};
 use iroh_pigeons::{
     Config, RoostConfig, ServiceParams, Tunnel, add_tunnel_host, home_ssh_dir, install_service,
-    list_tunnel_hosts, publish_telemetry_choice_for_service, remove_tunnel_host,
-    resolve_binary_path, restart_service, service_endpoint_id, service_log, uninstall_service,
+    list_tunnel_hosts, persistent_endpoint_id, publish_telemetry_choice_for_service,
+    remove_tunnel_host, resolve_binary_path, restart_service, service_endpoint_id, service_log,
+    uninstall_service,
 };
 use tokio::{
     fs,
@@ -67,6 +69,8 @@ pub enum Cmd {
     Version,
     /// Print the paths used for config and other files
     Paths,
+    /// Print the endpoint ID for a persistent identity
+    EndpointId(EndpointIdArgs),
 }
 
 #[derive(Subcommand, Clone, Debug)]
@@ -113,8 +117,23 @@ pub struct FlyArgs {
     #[arg(long, default_value_t = false)]
     pub stdio: bool,
 
+    /// Directory containing the persistent identity used by this client
+    #[arg(long, value_name = "DIR")]
+    pub key_dir: Option<PathBuf>,
+
+    /// Direct socket address for the remote endpoint (repeatable)
+    #[arg(long, value_name = "ADDR", action = ArgAction::Append)]
+    pub direct_address: Vec<SocketAddr>,
+
     #[arg(long, value_name = "URL", help = RELAY_URL_HELP, action = ArgAction::Append)]
     pub relay_url: Vec<String>,
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct EndpointIdArgs {
+    /// Directory containing the persistent identity
+    #[arg(long, value_name = "DIR")]
+    pub key_dir: Option<PathBuf>,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -308,23 +327,23 @@ async fn main() -> anyhow::Result<()> {
                 .await
         }
         Cmd::Fly(args) => {
-            let mut builder = Tunnel::builder_ephemeral().await?;
-            for url in &args.relay_url {
-                builder.relay_urls.push(
-                    RelayUrl::from_str(url)
-                        .map_err(|e| anyhow::anyhow!("invalid relay URL '{url}': {e}"))?,
-                );
-            }
+            let mut builder = match args.key_dir {
+                Some(key_dir) => Tunnel::builder_from_ssh_dir(key_dir).await?,
+                None => Tunnel::builder_ephemeral().await?,
+            };
+            let relay_urls = parse_relay_urls(&args.relay_url)?;
+            builder.relay_urls = relay_urls.clone();
             let tunnel = builder.build().await?;
             tunnel
                 .clone()
                 .close_after(async move {
                     let remote_id = EndpointId::from_str(&args.public_key)?;
+                    let remote = endpoint_addr(remote_id, relay_urls, args.direct_address);
 
                     if args.stdio {
-                        tunnel.fly_stdio(remote_id).await?;
+                        tunnel.fly_stdio(remote).await?;
                     } else {
-                        let fut = tunnel.fly(remote_id);
+                        let fut = tunnel.fly(remote);
                         tokio::select! {
                             res = fut => {
                                 if let Err(err) = res {
@@ -340,6 +359,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(())
                 })
                 .await
+        }
+        Cmd::EndpointId(args) => {
+            let key_dir = args.key_dir.unwrap_or(home_ssh_dir()?);
+            println!("{}", persistent_endpoint_id(key_dir).await?);
+            Ok(())
         }
         Cmd::Add(args) => {
             let name = args.name.unwrap_or_else(|| default_route_name(&args.id));
@@ -470,6 +494,29 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+fn parse_relay_urls(urls: &[String]) -> anyhow::Result<Vec<RelayUrl>> {
+    urls.iter()
+        .map(|url| {
+            RelayUrl::from_str(url).map_err(|e| anyhow::anyhow!("invalid relay URL '{url}': {e}"))
+        })
+        .collect()
+}
+
+fn endpoint_addr(
+    id: EndpointId,
+    relay_urls: Vec<RelayUrl>,
+    direct_addresses: Vec<SocketAddr>,
+) -> EndpointAddr {
+    relay_urls.into_iter().fold(
+        direct_addresses
+            .into_iter()
+            .fold(EndpointAddr::new(id), |addr, direct| {
+                addr.with_ip_addr(direct)
+            }),
+        |addr, relay| addr.with_relay_url(relay),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -524,6 +571,8 @@ mod tests {
         let stdio = Cmd::Fly(FlyArgs {
             public_key: "abc".to_string(),
             stdio: true,
+            key_dir: None,
+            direct_address: vec![],
             relay_url: vec![],
         });
         assert!(!should_ask_about_telemetry(&stdio));
@@ -535,9 +584,26 @@ mod tests {
         assert!(!should_ask_about_telemetry(&Cmd::List));
         assert!(!should_ask_about_telemetry(&Cmd::Version));
         assert!(!should_ask_about_telemetry(&Cmd::Paths));
+        assert!(!should_ask_about_telemetry(&Cmd::EndpointId(
+            EndpointIdArgs { key_dir: None }
+        )));
         assert!(!should_ask_about_telemetry(&Cmd::Service {
             op: ServiceCmd::Status
         }));
+    }
+
+    #[tokio::test]
+    async fn endpoint_addr_includes_explicit_relay_and_direct_routes() {
+        let id = persistent_endpoint_id(tempfile::tempdir().unwrap().path().to_path_buf())
+            .await
+            .unwrap();
+        let relay: RelayUrl = "https://relay.example.com".parse().unwrap();
+        let direct: SocketAddr = "192.0.2.1:4242".parse().unwrap();
+
+        let addr = endpoint_addr(id, vec![relay], vec![direct]);
+
+        assert!(addr.addrs.iter().any(|address| address.is_relay()));
+        assert!(addr.addrs.iter().any(|address| address.is_ip()));
     }
 
     /// Regression: the ID is not validated until after the name is derived, so

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -42,6 +42,11 @@ pub async fn dot_ssh_secret_key(ssh_dir: PathBuf) -> anyhow::Result<SecretKey> {
     }
 }
 
+/// Load or create the persistent identity stored in `ssh_dir` and return its endpoint ID.
+pub async fn persistent_endpoint_id(ssh_dir: PathBuf) -> anyhow::Result<PublicKey> {
+    Ok(dot_ssh_secret_key(ssh_dir).await?.public())
+}
+
 /// Write the secret key, readable only by its owner on unix.
 ///
 /// This key is the roost's identity, so anyone able to read it can impersonate

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{Context, Result, anyhow};
 use iroh::{
-    Endpoint, EndpointId, RelayUrl, SecretKey,
+    Endpoint, EndpointAddr, RelayUrl, SecretKey,
     endpoint::{RelayMode, presets},
     protocol::Router,
 };
@@ -135,18 +135,19 @@ impl Tunnel {
         Ok(builder)
     }
 
-    pub async fn fly(&self, remote: EndpointId) -> Result<()> {
+    pub async fn fly(&self, remote: impl Into<EndpointAddr>) -> Result<()> {
         let bind_addr = format!("127.0.0.1:{}", 0);
         let listener = TcpListener::bind(&bind_addr).await?;
         tracing::info!("fly: listening on {}", listener.local_addr()?);
-        prepare_pigeon(self.endpoint().clone(), listener, remote).await
+        prepare_pigeon(self.endpoint().clone(), listener, remote.into()).await
     }
 
     /// Bridge stdin/stdout directly to a remote roost via iroh.
     /// Designed for use as an SSH ProxyCommand:
     ///   ProxyCommand pigeons fly --stdio <endpoint_id>
-    pub async fn fly_stdio(&self, remote: EndpointId) -> Result<()> {
-        tracing::debug!("fly_stdio: connecting to {remote}");
+    pub async fn fly_stdio(&self, remote: impl Into<EndpointAddr>) -> Result<()> {
+        let remote = remote.into();
+        tracing::debug!("fly_stdio: connecting to {}", remote.id);
         let conn = self
             .endpoint()
             .connect(remote, PigeonsProtocol::ALPN)
@@ -198,13 +199,14 @@ impl Tunnel {
 async fn prepare_pigeon(
     endpoint: Endpoint,
     listener: TcpListener,
-    remote: EndpointId,
+    remote: EndpointAddr,
 ) -> Result<()> {
     loop {
         match listener.accept().await {
             Ok((tcp_stream, peer_addr)) => {
                 tracing::info!("pigeon departing from {peer_addr}");
                 let endpoint = endpoint.clone();
+                let remote = remote.clone();
                 tokio::spawn(async move {
                     if let Err(e) = bridge_connection(tcp_stream, &endpoint, remote).await {
                         tracing::error!("pigeon lost in transit: {e}");
@@ -223,11 +225,11 @@ async fn prepare_pigeon(
 async fn bridge_connection(
     tcp_stream: TcpStream,
     endpoint: &Endpoint,
-    remote_id: EndpointId,
+    remote: EndpointAddr,
 ) -> anyhow::Result<()> {
     tcp_stream.set_nodelay(true)?;
-    tracing::debug!("bridge_connection: connecting to {remote_id}");
-    let conn = endpoint.connect(remote_id, PigeonsProtocol::ALPN).await?;
+    tracing::debug!("bridge_connection: connecting to {}", remote.id);
+    let conn = endpoint.connect(remote, PigeonsProtocol::ALPN).await?;
     tracing::debug!("bridge_connection: connected, opening bi stream");
     let (mut iroh_send, mut iroh_recv) = conn.open_bi().await?;
     let (mut tcp_read, mut tcp_write) = tcp_stream.into_split();


### PR DESCRIPTION
## Summary
- add `pigeons endpoint-id [--key-dir DIR]` for a reusable client identity
- let `fly --key-dir DIR` use that identity instead of an ephemeral key
- accept repeated remote `--direct-address` values
- attach explicit relay URLs and direct addresses to the remote `EndpointAddr`
- keep existing library callers source-compatible through `Into<EndpointAddr>`

## Why this belongs in pigeons
`fly` currently creates its secret key and calls `Endpoint::connect` inside the process. A wrapper cannot supply a persistent identity or the remote relay/direct candidates required for private relay discovery. The CLI additions expose only generic iroh transport inputs.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked`
- deterministic endpoint address test covering relay and direct candidates
- existing key persistence and owner-only permission tests remain green

This does not add application policy, access grants, auth tokens, or SSH trust decisions.