### PR TITLE
fix(config): wait for pending file writes before returning

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,7 @@ impl Config {
             .open(config_file_path)
             .await?;
         file.write_all(toml::to_string(self)?.as_bytes()).await?;
+        file.flush().await?;
         Ok(())
     }
 


### PR DESCRIPTION
Config::store_to currently returns after Tokio write_all, which may leave a background file write pending. Immediate reload can therefore observe an empty config. This caused the existing stored_telemetry_choice_round_trips test to fail in a Linux amd64 build (None instead of Some(false)).

Await flush at the shared storage boundary before returning. This is write completion, not a new crash-durability/fsync guarantee; no transport or application policy changes.

Verification: cargo fmt --all -- --check and cargo test --locked passed (19 library and 9 binary tests), including the existing round-trip regression. The diff against upstream main is one insertion in src/config.rs.